### PR TITLE
Api/settings

### DIFF
--- a/plasmad/src/api/rest_api.py
+++ b/plasmad/src/api/rest_api.py
@@ -12,6 +12,7 @@ from src.api.projects import api as project_routes
 from src.api.workflows import api as workflow_routes
 from src.api.executions import api as execution_routes
 from src.api.models import api as model_routes
+from src.api.settings import api as settings_routes
 import logging
 import sys
 
@@ -27,6 +28,7 @@ api.add_namespace(project_routes, path='/project')
 api.add_namespace(workflow_routes, path='/workflow')
 api.add_namespace(execution_routes, path='/execution')
 api.add_namespace(model_routes, path='/model')
+api.add_namespace(settings_routes, path='/settings')
 # api.add_namespace(component_routes,path='/component')
 # api.init_app(app)
 

--- a/plasmad/src/api/settings.py
+++ b/plasmad/src/api/settings.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import werkzeug
+# Werkzeug 1.0.0 breaks flask_restplus, need to keep this line in
+# till flask restplus patches this
+werkzeug.cached_property = werkzeug.utils.cached_property
+from xxhash import xxh32_intdigest
+from flask_restplus import Namespace, Resource, fields, marshal, reqparse
+from src.utils.api_utils import *
+from src.utils.decorators import *
+from src.utils.db_utils import get_plasma_db
+
+api = Namespace('settings', description='routes for managing plasma settings')
+
+settings = api.model('Settings', {
+    'automatic-crash-reporting': fields.Integer(required=True, description='Enable automatic crash reporting'),
+    'plasma-auth-key': fields.String(required=True, description='Plasma authentication key'),
+})
+
+
+@api.route('')
+class Settings(Resource):
+    @api.doc('Get plasma settings')
+    def get(self):
+        db = get_plasma_db()
+        settings_collection = db.get_collection('settings')
+        result = settings_collection.find_one({'settings-type': 'general'})
+        if result:
+            response_data = marshal(result, settings)
+            response = generate_response(200, response_data)
+        else:
+            response = generate_response(404)
+        return response
+
+    @api.doc('Update settings')
+    def put(self):
+        parser = reqparse.RequestParser()
+        parser.add_argument('update', type=dict, required=True,
+                            help='values which need to be updated')
+        args = parser.parse_args()
+        db = get_plasma_db()
+        settings_collection = db.get_collection('settings')
+        updated_resource = project_collection.find_one_and_update(
+            {"settings-type": 'general'},
+            {"$set": dict(args)}
+        )
+        if updated_resource:
+            response = generate_response(204)
+        else:
+            response = generate_response(404)
+        return response


### PR DESCRIPTION
Adds a /settings route to plasma-core,

currently, the settings model has 3 fields : 

1. settings-type  ( String )
2. automatic-crash-reporting ( Integer )
3. plasma-auth-key ( String )


we can later extend settings by adding more settings types ( provisioning, security, etc. ) 